### PR TITLE
Fix incorrect memory allocation by aligning element computation with tensor extents

### DIFF
--- a/nvpl_tensor/contraction/contraction.c
+++ b/nvpl_tensor/contraction/contraction.c
@@ -67,17 +67,17 @@ int main()
     int64_t elementsA = 1;
     for (int i = 0; i < nmodeA; ++i)
     {
-        elementsA *= extent[i];
+        elementsA *= extentA[i];
     }
     int64_t elementsB = 1;
     for (int i = 0; i < nmodeB; ++i)
     {
-        elementsB *= extent[i];
+        elementsB *= extentB[i];
     }
     int64_t elementsC = 1;
     for (int i = 0; i < nmodeC; ++i)
     {
-        elementsC *= extent[i];
+        elementsC *= extentC[i];
     }
 
     int64_t sizeA = sizeof(floatTypeA) * elementsA;


### PR DESCRIPTION
This PR fixes a segmentation fault that occurs during tensor memory allocation for large extents.

The issue stems from using the global extent array when computing elementsA, elementsB, and elementsC. While this works under the original toy example {6, 6, 6, 4, 4, 4}, it breaks when dimensions and mode mappings differ, as seen in configurations such as {1, 8, 512, 8, 512}.

The fix replaces usage of extent[...] with the corresponding per-tensor extents (extentA, extentB, and extentC), which are already calculated properly based on mode permutations. This ensures the memory allocation aligns with how the tensor descriptors are defined.

Tested using NVIDIA Grace with this [repo](https://github.com/accable/hpc_toy/blob/main/src/attention/2_0_multi_head_attention_cutensor.c)